### PR TITLE
Updated required Xamarin Forms package version

### DIFF
--- a/installation-and-deployment/required-android-support-libraries.md
+++ b/installation-and-deployment/required-android-support-libraries.md
@@ -11,7 +11,7 @@ The controls in the suite require specific Xamarin Android Support Libraries to 
 
 Here are listed the common requirements for all Android projects that use our suite:
 
-- The required version of **Xamarin.Forms** package is **2.2.0.31**.
+- The required version of **Xamarin.Forms** package is **2.2.0.45**.
 - The required version of all Xamarin Android Support Libraries is **23.3.0**.
 - Here are listed all packages that come with the latest version of Xamarin.Forms, which also have to be updated to version **23.3.0**:
  - Xamarin.Android.Support.v4


### PR DESCRIPTION
According to the latest DLLs available for download (2016.2.614.220), the required Xamarin Forms version is 2.2.0.45. I have updated this page to reflect that requirement.
