### PR TITLE
Doc Feedback Fix - Replace ellipses with valid XAML content

### DIFF
--- a/controls/sidedrawer/features/sidedrawer-features-commands.md
+++ b/controls/sidedrawer/features/sidedrawer-features-commands.md
@@ -51,10 +51,10 @@ Once such command is created it can be used in XAML like this:
         <local:CustomUserCommand/>
       </primitives:RadSideDrawer.Commands>
       <primitives:RadSideDrawer.MainContent>
-        ...
+         <Label Text="Main content" />
       </primitives:RadSideDrawer.MainContent>
       <primitives:RadSideDrawer.DrawerContent>
-		...
+	 <Label Text="Drawer content" />
       </primitives:RadSideDrawer.DrawerContent>
     </primitives:RadSideDrawer>
 


### PR DESCRIPTION
This fix is to address documentation feedback from a user who said this code did not work unless they skipped XAML compilation.