### PR TITLE
Doc Feedback Fix - Calendar Custom Renderer articles

### DIFF
--- a/controls/calendar/how-to/calendar-how-to-create-custom-renderer.md
+++ b/controls/calendar/how-to/calendar-how-to-create-custom-renderer.md
@@ -8,17 +8,10 @@ slug: calendar-how-to-create-custom-renderer
 # Custom Calendar Renderer #
 Sometimes, you might find that certain feature is available in the native control on a given platform, but is not exposed in Xamarin Forms. This is when you would need to create a custom renderer. This will allow you to access the native control and configure it as per your needs.
 
-## Example ##
+## Examples ##
 
-Currently, Xamarin Forms do not expose the ability to choose specific color for an event. This can be easily achieved by creating a custom renderer for **RadCalendar**.  Here is an example for Android. The custom renderer can inherit from **Telerik.XamarinForms.InputRenderer.Android.CalendarRenderer**. This way you can take advantage of all the features that are already in there and only add the coloring for events. Override the **OnElementChanged** method and set the color for the event:
+You can find Custom Renderer examples at each of the following RadCalendar articles:
 
-	public class CustomCalendarRenderer : CalendarRenderer
-	{
-		protected override void OnElementChanged(ElementChangedEventArgs<RadCalendar> e)
-		{
-			base.OnElementChanged(e);
-			if (this.Control.EventAdapter.Events.Count > 0)
-				this.Control.EventAdapter.Events[0].EventColor = Color.Yellow;
-		}
-	}
-
+- [Android]({%slug calendar-custom-renderers-android%})
+- [iOS]({%slug calendar-custom-renderers-ios%})
+- [UWP]({%slug calendar-custom-renderers-uwp%})

--- a/controls/calendar/styling/custom-renderers/calendar-customrenderers-uwp.md
+++ b/controls/calendar/styling/custom-renderers/calendar-customrenderers-uwp.md
@@ -2,7 +2,7 @@
 title: Calendar UWP Custom Renderers
 page_title: Calendar UWP Custom Renderer
 position: 0
-slug: calendar-custom-renderers-android
+slug: calendar-custom-renderers-uwp
 ---
 
 # Custom Calendar Renderer


### PR DESCRIPTION
There are two changes:

- Slug fix for the UWP custom renderer article
- Point the reader to the existing articles for custom renderers, instead of showing only an Android example