### PR TITLE
Update bar-series.md

### DIFF
--- a/controls/chart/series/cartesian/bar-series.md
+++ b/controls/chart/series/cartesian/bar-series.md
@@ -12,7 +12,7 @@ position: 0
 
 The **BarSeries** inherits from **CategoricalSeries** and requires one **CategoricalAxis** and one **NumericalAxis**. 
 
->tip You could check the common CategoricalSeries features that are also applicable to **BarSeries** at the following link: [Series Features]({%slug chart-series-overview %}##features).
+>tip You could check the common CategoricalSeries features that are also applicable to **BarSeries** at the following link: [Series Features]({%slug chart-series-overview %}).
 
 ## Example ##
 


### PR DESCRIPTION
removed the `##features` addition to the slug, it breaks the the generated hyperlink.'

I tried finding documentation how to to tweak the slug so that you can use an ID to jump down, but wasn't successful.