### PR TITLE
Update chart-getting-started.md

### DIFF
--- a/nativecontrols/android/chart/chart-getting-started.md
+++ b/nativecontrols/android/chart/chart-getting-started.md
@@ -51,10 +51,10 @@ Here, `MonthResult` is a custom type that we have defined as follows. Additional
 ```C#
 	public class MonthResult : Java.Lang.Object {
 
-		public String Month { get; set; }
+		public string Month { get; set; }
 		public double Result { get; set; }
 
-		public MonthResult(String month, double result) {
+		public MonthResult(string month, double result) {
 			this.Month = month;
 			this.Result = result;
 		}


### PR DESCRIPTION
Because there are four different `String` types, which causes build errors or confusion unless explicitly defined, I changed it to lowercase `string` to use System.String instead. 

This makes for using the example significantly easier for Xamarin.Android devs