### PR TITLE
Add checkbox styling article

### DIFF
--- a/controls/checkbox/checkbox-key-features.md
+++ b/controls/checkbox/checkbox-key-features.md
@@ -43,10 +43,7 @@ Here is the end result with available states defined:
 
 ![CheckBox Key Feature Example](images/checkbox-features.png)
 
-## Styling
-
- See [CheckBox Styling]({% slug checkbox-styling%}) for options for visual appearance.
-
 ## See Also
 
 - [CheckBox Getting Started]({% slug checkbox-getting-started%})
+- [CheckBox Styling]({% slug checkbox-styling%}) 

--- a/controls/checkbox/checkbox-key-features.md
+++ b/controls/checkbox/checkbox-key-features.md
@@ -9,40 +9,7 @@ slug: checkbox-key-features
 
 The purpose of this help article is to show you the key features of the **RadCheckBox** control. 
 
-## Color Changing Options
 
-RadCheckBox exposes a few useful Color properties for customizing its visual appearance. You could set the color of the check mark as well as the control itself in each of the available states.
-
- * **CheckedColor**: Defines the Color applied to the control when it is checked.
- 
-<snippet id='checkbox-color-changing-checkedcolor-xaml'/>
-
- * **CheckedSymbolColor**: Defines the Color applied to the check symbol of the control when it is in Checked state.
- 
-<snippet id='checkbox-color-changing-checkedsymbolcolor-xaml'/>
-
- * **IndeterminateColor**: Defines the Color applied to the control when it is in Indeterminate state.
- * **IndeterminateSymbolColor**: Defines the Color applied to the Indeterminate symbol of the control.
-
-Here is an example how to apply indeterminate color and indeterminate symbol color:
-
-<snippet id='checkbox-color-changing-inderetminatecolorsymbolcolor-xaml'/>
-
- * **UncheckedColor**: Defines the Color applied to the control when it is unchecked.
-
-<snippet id='checkbox-color-changing-uncheckedcolor-xaml'/>
-
-Here is the end result with all color changing options:
-
-![CheckBox Color Changing Options Example](images/checkbox-colors.png)
-
-## Stroke Width Customization
-
-The RadCheckBox control exposes a **StrokeWidth** property that specifies the width of the lines with which the Checkbox element is drawn. It affects the outline of the control as well as the check mark.
-
-Here is an example how you can apply a stroke width value:
-
-<snippet id='checkbox-key-features-strokewidth-xaml'/>
 
 ## CheckBox States
 
@@ -82,6 +49,10 @@ There are two types of commands:
 Here is the end result with stroke width, size and state customization:
 
 ![CheckBox Key Feature Example](images/checkbox-features.png)
+
+## Styling
+
+ See [CheckBox Styling]({% slug checkbox-styling%}) for options for visual appearance.
 
 ## See Also
 

--- a/controls/checkbox/checkbox-key-features.md
+++ b/controls/checkbox/checkbox-key-features.md
@@ -9,8 +9,6 @@ slug: checkbox-key-features
 
 The purpose of this help article is to show you the key features of the **RadCheckBox** control. 
 
-
-
 ## CheckBox States
 
 RadCheckBox provides three states – **Checked**, **Unchecked** and **Indeterminate**. The state is controlled through the **IsChecked** property which is of type bool?. The state could be set either through the UI or programmatically as explained below:
@@ -24,19 +22,6 @@ Here is an example how you can set the **Indeterminate** state:
 
 <snippet id='checkbox-key-features-ischeckednull-xaml'/>
 
-## CheckBox Size
-
-The size of the checkbox is controlled through the **Length** property, this snippet shows how you can apply it.
-
-<snippet id='checkbox-key-features-length-xaml'/>
-
-### Stroke Width
-
-The RadCheckBox control exposes a **StrokeWidth** property that specifies the width of the lines with which the Checkbox element is drawn. It affects the outline of the control as well as the check mark.
-
-Here is an example how you can apply a stroke width value:
-
-<snippet id='checkbox-key-features-strokewidth-xaml'/>
 
 ## Commands
 

--- a/controls/checkbox/checkbox-key-features.md
+++ b/controls/checkbox/checkbox-key-features.md
@@ -30,6 +30,14 @@ The size of the checkbox is controlled through the **Length** property, this sni
 
 <snippet id='checkbox-key-features-length-xaml'/>
 
+### Stroke Width
+
+The RadCheckBox control exposes a **StrokeWidth** property that specifies the width of the lines with which the Checkbox element is drawn. It affects the outline of the control as well as the check mark.
+
+Here is an example how you can apply a stroke width value:
+
+<snippet id='checkbox-key-features-strokewidth-xaml'/>
+
 ## Commands
 
 RadCheckBox exposes a Commands collection that allows you to register custom commands with each control’s instance through the **Commands** property:

--- a/controls/checkbox/checkbox-key-features.md
+++ b/controls/checkbox/checkbox-key-features.md
@@ -39,7 +39,7 @@ There are two types of commands:
 	* **Command**: Gets or sets the generic **ICommand** implementation.
 	* **SuppressDefaultCommand**: Gets or sets a value indicating whether the default(built-in) UI command associated with the specified **Id** will be executed.
 
-Here is the end result with stroke width, size and state customization:
+Here is the end result with available states defined:
 
 ![CheckBox Key Feature Example](images/checkbox-features.png)
 

--- a/controls/checkbox/checkbox-overview.md
+++ b/controls/checkbox/checkbox-overview.md
@@ -14,13 +14,17 @@ slug: checkbox-overview
 
 ## Key features
 
- * **Color changing options**: You will be able to set various Color properties to make changes to the look of different parts of the CheckBox control, check [here]({% slug checkbox-key-features %}#color-changing-options) for more details.
- * **Stroke Width customization**: You will have the option to customize the layout of the CheckBox, including the borders and the check mark, read more [here]({%slug checkbox-key-features %}#stroke-width-customization).
- * **Indeterminate state**: RadCheckBox provides an additional indeterminate state which indicates the control is neither checked nor unchecked, for more details go [here]({%slug checkbox-key-features %}#checkbox-states).
- * **Different sizes**: You will be able to set the dimension of the CheckBox by adjusting only one property - the Length property, check the details [here]({%slug checkbox-key-features %}#checkbox-size).
+ * **Indeterminate state support**: RadCheckBox provides an additional indeterminate state which indicates the control is neither checked nor unchecked, for more details go [here]({%slug checkbox-key-features %}#checkbox-states).
  * **Commands support**: CheckBox exposes a Commands collection that allows you to register custom commands with each control’s instance, read more [here]({%slug checkbox-key-features %}#commands).
- * **Theming Support**: RadCheckBox comes with built-in theming support that allows you to easily build slick interfaces with the look-and-feel of a predefined theme.
+
+
+## Styling Features
+ * **Color customization**: You will be able to set various Color properties to make changes to the look of different parts of the CheckBox control, check [here]({% slug checkbox-styling %}#colors) for more details.
+ * **Stroke Width customization**: You will have the option to customize the layout of the CheckBox, including the borders and the check mark, read more [here]({%slug checkbox-styling %}#stroke-width).
+  * **Different sizes**: You will be able to set the dimension of the CheckBox by adjusting only one property - the Length property, check the details [here]({%slug checkbox-styling %}#checkbox-length).
+  * **Theming Support**: RadCheckBox comes with built-in theming support that allows you to easily build slick interfaces with the look-and-feel of a predefined theme. See the Theme color keys [here]({%slug checkbox-styling %}#theme)
 
 ## See Also
 
 - [Getting Started]({%slug checkbox-getting-started %})
+- [CheckBox Styling]({% slug checkbox-styling%})

--- a/controls/checkbox/checkbox-styling.md
+++ b/controls/checkbox/checkbox-styling.md
@@ -1,0 +1,92 @@
+﻿---
+title: Styling
+page_title: Styling
+position: 3
+slug: checkbox-styling
+---
+
+# Styling
+
+The purpose of this help article is to show you the styling options of the **RadCheckBox** control. 
+
+## CheckBox Length
+
+The width and height of the checkbox is controlled through the **Length** property and maintains a 1:1 aspect ratio. 
+
+Here is an example of setting the `Length` value:
+
+<snippet id='checkbox-key-features-length-xaml'/>
+
+## Stroke Thickness
+
+The RadCheckBox control exposes a **StrokeWidth** property that specifies the width of the lines with which the Checkbox element is drawn. It affects the border of the control as well as the check mark.
+
+Here is an example how you can apply a `StrokeWidth` value:
+
+<snippet id='checkbox-key-features-strokewidth-xaml'/>
+
+### Example
+
+Here is the result at runtime showing the above StrokeWidth and Length examples:
+
+![CheckBox Key Feature Example](images/checkbox-features.png)
+
+## Colors
+
+RadCheckBox exposes a few useful Color properties for customizing its visual appearance. You could set the color of the check mark as well as the control itself in each of the available states.
+
+ * Background/Border Colors
+   * **CheckedColor**: Defines the Color applied to the control when it is checked. This is both the border and background color.
+   * **UncheckedColor**: Defines the Color applied to the control when it is unchecked. This is the border color only, the background is transparent when unchecked.
+   * **IndeterminateColor**: Defines the Color applied to the control when it is in Indeterminate state. This is both the border and background color.
+ * Symbol Colors
+   * **CheckedSymbolColor**: Defines the Color applied to the check symbol of the control when it is in Checked state.
+   * **IndeterminateSymbolColor**: Defines the Color applied to the Indeterminate symbol of the control.
+
+### Example
+Here is an example how to apply indeterminate color and indeterminate symbol color:
+
+Checked Color
+<snippet id='checkbox-color-changing-checkedcolor-xaml'/>
+
+UncheckedColor
+<snippet id='checkbox-color-changing-uncheckedcolor-xaml'/>
+
+CheckedSymbol
+<snippet id='checkbox-color-changing-checkedsymbolcolor-xaml'/>
+
+Indeterminate and IndeterminateSymbol Color
+<snippet id='checkbox-color-changing-inderetminatecolorsymbolcolor-xaml'/>
+
+
+Here is the result at runtime with all of the above examples:
+
+![CheckBox Color Changing Options Example](images/checkbox-colors.png)
+
+
+## Theme
+
+Telerik UI for Xamarin allows you to override the default theme and provide an entire set of colors across all the controls in a custom theme. Visit the [Modifying the Default Theme]({% slug checkbox-getting-started%}) article for more instructions.
+
+The colors you can set in the custom theme are as follows
+
+```xml
+<!-- CheckBox -->
+<Color x:Key="TelerikCheckBoxCheckedColor">#3148CA</Color>
+<Color x:Key="TelerikCheckBoxCheckedSymbolColor">White</Color>
+<Color x:Key="TelerikCheckBoxIndeterminateColor">#3148CA</Color>
+<Color x:Key="TelerikCheckBoxIndeterminateSymbolColor">White</Color>
+<Color x:Key="TelerikCheckBoxUncheckedColor">#919191</Color>
+```
+
+To use the custom theme on any RadCheckBox instance, set the `StyleClass="Telerik"`, here's an example:
+
+```xml
+<primitives:RadCheckBox StyleClass="Telerik" />
+```
+
+
+## See Also
+
+- [CheckBox Getting Started]({% slug checkbox-getting-started%})
+- [CheckBox Key Features]({% slug checkbox-key-features%})


### PR DESCRIPTION
The new Styling article takes some content from the Key Features article, along with a little more info about theme, to provide a clearer availability of the styling capability of the RadCheckBox

This is an attempt to respond to some major feedback we've received recently where the checkbox didn't have any styling options. 

@stefanov-stefan These are the changes I promised to deliver in our email chain about the feedback from the social media complaint.