### PR TITLE
Added Collapse and Expand method instructions

### DIFF
--- a/controls/datagrid/grouping.md
+++ b/controls/datagrid/grouping.md
@@ -88,6 +88,58 @@ The following property is used to enable/disable the grouping of a specific colu
 
 >important A sample Grouping example can be found in the DataGrid/Grouping folder of the [SDK Samples Browser application]({%slug developer-focused-examples%}).
 
+## Expand and Collapse Groups
+
+**RadDataGrid** supports groups expand and collapse operations either through the UI by tapping on the group headers or programmatically. By default, all the groups are expanded.
+
+This help topic will provide an overview of the methods and commands used to control the expand/collapse state of the ListView groups.
+
+### Get the grouped ListView items
+
+To manipulate the collapsible DataGrid groups, first you will need to call its **GetDataView** method. In short, GetDataView method provides a view of the ItemsSource after all the Sort, Group and Filter operations are applied.  The return type is *IDataViewCollection* which exposes the expand and collapse methods described in the following sections.
+
+```C#
+var dataView = this.dataGrid.GetDataView();
+```
+
+### Expand and collapse all groups 
+
+In order to expand all groups, use the **ExpandAll** method and respectively use the **CollapseAll** method - to collapse all groups.
+
+```C#
+//expand all
+var dataView = this.dataGrid.GetDataView();
+dataView.ExpandAll();
+
+//collapse all
+var dataView = this.dataGrid.GetDataView();
+dataView.CollapseAll();
+```
+
+### Expand and collapse a certain group
+
+You could retrieve the first-level groups through the **GetGroups** method of the *IDataViewCollection* object and use **ExpandGroup**/**CollapseGroup** to make a certain group to expand or collapse respectively. You could check whether a group is expanded trough the **GetIsExpanded** method.
+
+Here is quick snippet on how these methods are used:
+
+```C# 
+var dataView = this.dataGrid.GetDataView();
+var rootGroups = dataView.GetGroups();
+
+var isFirstExpanded = dataView.GetIsExpanded(rootGroups.First());
+//expand a certain group
+dataView.ExpandGroup(rootGroups.First());
+//collapse a certain group
+dataView.CollapseGroup(rootGroups.First());
+```
+Additionally, *IDataViewCollection* provides **ExpandItem**/**CollapseItem** methods that takes a data item as a parameter and expand/collapse the immediate group containing this item.	
+
+```C#
+var lastItem = (dataGrid.ItemsSource as IEnumerable<City>).Last();
+var dataView = this.dataGrid.GetDataView();
+dataView.CollapseItem(lastItem);
+```
+
 ## See Also
 
 - [Filtering]({%slug datagrid-filtering-overview%})


### PR DESCRIPTION
The instructions were missing the DataView's methods to expand and collapse the groups, this update brings parity with the RadListView's grouping instructions.