### PR TITLE
Update telerik-font-icons.md

### DIFF
--- a/styling-and-appearance/telerik-font-icons.md
+++ b/styling-and-appearance/telerik-font-icons.md
@@ -67,11 +67,11 @@ You can choose any of the available Telerik Font icons:
 
 | Telerik Font Icons |  |  | | | | 
 |--------------------|----------------|------------|---------------------|-------------------|----------------|
-| <span class="icon-sort_descent"></span> sort_descent | __\&#xe800;__ | <span class="icon-star-empty"></span> star-empty | __\&#xe801;__ | <span class="icon-filter"></span> filter | __\&#xe802;__ |
-| <span class="icon-sort_ascent"></span> sort_ascent | __\&#xe803;__ | <span class="icon-group"></span> group | __\&#xe804;__ | <span class="icon-star"></span> star | __\&#xe805;__ |
-| <span class="icon-right-dir"></span> right-dir | __\&#xe806;__ | <span class="icon-dots_vert"></span> dots_vert | __\&#xe807;__ | <span class="icon-menu"></span> menu | __\&#xe808;__ |
+| <span class="icon-sort_descent"></span> sort descent | __\&#xe800;__ | <span class="icon-star-empty"></span> star-empty | __\&#xe801;__ | <span class="icon-filter"></span> filter | __\&#xe802;__ |
+| <span class="icon-sort_ascent"></span> sort ascent | __\&#xe803;__ | <span class="icon-group"></span> group | __\&#xe804;__ | <span class="icon-star"></span> star | __\&#xe805;__ |
+| <span class="icon-right-dir"></span> right-dir | __\&#xe806;__ | <span class="icon-dots_vert"></span> dots vert | __\&#xe807;__ | <span class="icon-menu"></span> menu | __\&#xe808;__ |
 | <span class="icon-check"></span> check | __\&#xe809;__ | <span class="icon-cancel"></span> cancel | __\&#xe80a;__ | <span class="icon-dot"></span> dot | __\&#xe80b;__ |
-| <span class="icon-dot-3"></span> check | __\&#xe80c;__ | <span class="icon-down-dir"></span> down-dir | __\&#xe80d;__ | <span class="icon-left-open-big"></span> left-open-big | __\&#xe80e;__ |
+| <span class="icon-dot-3"></span> dot-3 | __\&#xe80c;__ | <span class="icon-down-dir"></span> down-dir | __\&#xe80d;__ | <span class="icon-left-open-big"></span> left-open-big | __\&#xe80e;__ |
 | <span class="icon-cog"></span> configure | __\&#xe80f;__ | <span class="icon-search"></span> search | __\&#xe810;__ | <span class="icon-up-dir"></span> up-dir | __\&#xe811;__ |
 | <span class="icon-pattern"></span> pattern | __\&#xe812;__ | <span class="icon-add"></span> add | __\&#xe813;__ | <span class="icon-right-dir-outlines"></span> right-dir-outlines | __\&#xe814;__ |
 | <span class="icon-info"></span> info | __\&#xe815;__ | <span class="icon-down-dir-outlines"></span> down-dir-outlines | __\&#xe816;__ | <span class="icon-bin-solid"></span> bin-solid | __\&#xe817;__ |
@@ -85,7 +85,7 @@ You can choose any of the available Telerik Font icons:
 | <span class="icon-spam"></span> spam | __\&#xe82e;__ | <span class="icon-warning"></span> warning | __\&#xe82f;__ | <span class="icon-lock"></span> lock | __\&#xe830;__ |
 | <span class="icon-thickness"></span> thickness | __\&#xe831;__ | <span class="icon-car"></span> car | __\&#xe832;__ | <span class="icon-shopping-bag"></span> shopping-bag | __\&#xe833;__ |
 | <span class="icon-coffee-cup"></span> coffee-cup | __\&#xe834;__ | <span class="icon-get-money"></span> get-money | __\&#xe835;__ | <span class="icon-user"></span> shopping-user | __\&#xe836;__ |
-| <span class="icon-group_users"></span> group_users | __\&#xe837;__ | <span class="icon-dashboard"></span> dashboard | __\&#xe838;__ | <span class="icon-location-1"></span> location | __\&#xe83d;__ |
+| <span class="icon-group_users"></span> group users | __\&#xe837;__ | <span class="icon-dashboard"></span> dashboard | __\&#xe838;__ | <span class="icon-location-1"></span> location | __\&#xe83d;__ |
 | <span class="icon-link-1"></span> link | __\&#xe83e;__ | <span class="icon-assets"></span> assets | __\&#xe846;__ | <span class="icon-book"></span> book | __\&#xe847;__ |
 | <span class="icon-design"></span> design | __\&#xe848;__ | <span class="icon-graphics"></span> graphics | __\&#xe849;__ | <span class="icon-image"></span> image | __\&#xe84a;__ |
 | <span class="icon-font-size"></span> font-size | __\&#xe84b;__ | <span class="icon-template"></span> template | __\&#xe84c;__ | <span class="icon-wireframes"></span> wireframes | __\&#xe84d;__ |
@@ -95,13 +95,13 @@ You can choose any of the available Telerik Font icons:
 | <span class="icon-network2"></span> network | __\&#xe857;__ | <span class="icon-bar-chart"></span> bar-chart | __\&#xe858;__ | <span class="icon-sap"></span> sap | __\&#xe859;__ |
 | <span class="icon-dba"></span> dba | __\&#xe85a;__ | <span class="icon-home"></span> home | __\&#xe85b;__ | <span class="icon-temperature"></span> temperature | __\&#xe85c;__ |
 | <span class="icon-phone1"></span> phone | __\&#xe85d;__ | <span class="icon-electricity"></span> electricity | __\&#xe85e;__ | <span class="icon-wifi"></span> wifi | __\&#xe85f;__ |
-| <span class="icon-distance-horizontal"></span> distance-horizontal | __\&#xe860;__ | <span class="icon-calendar_dayview"></span> calendar_dayview | __\&#xe861;__ | <span class="icon-calendar_multiday"></span> calendar_multiday | __\&#xe862;__ |
-| <span class="icon-calendar_week"></span> calendar_week | __\&#xe863;__ | <span class="icon-calendar_month"></span> calendar_month | __\&#xe864;__ | <span class="icon-calendar_year2"></span> calendar_year | __\&#xe865;__ |
+| <span class="icon-distance-horizontal"></span> distance-horizontal | __\&#xe860;__ | <span class="icon-calendar_dayview"></span> calendar dayview | __\&#xe861;__ | <span class="icon-calendar_multiday"></span> calendar multiday | __\&#xe862;__ |
+| <span class="icon-calendar_week"></span> calendar week | __\&#xe863;__ | <span class="icon-calendar_month"></span> calendar month | __\&#xe864;__ | <span class="icon-calendar_year2"></span> calendar year | __\&#xe865;__ |
 | <span class="icon-calendar_selection_single"></span> calendar selection single | __\&#xe866;__ | <span class="icon-calendar_selection_multiple"></span> calendar selection multiple | __\&#xe867;__ | <span class="icon-calendar_selection_range"></span> calendar selection range | __\&#xe868;__ |
-| <span class="icon-gallery"></span> gallery | __\&#xe869;__ | <span class="icon-camera"></span> camera | __\&#xe86a;__ | <span class="icon-crop_free"></span> crop_free | __\&#xe86b;__ |
-| <span class="icon-crop_original"></span> crop_original | __\&#xe86c;__ | <span class="icon-crop_rect"></span> crop_rect | __\&#xe86d;__ | <span class="icon-crop_circular"></span> crop_circular | __\&#xe86e;__ |
+| <span class="icon-gallery"></span> gallery | __\&#xe869;__ | <span class="icon-camera"></span> camera | __\&#xe86a;__ | <span class="icon-crop_free"></span> crop free | __\&#xe86b;__ |
+| <span class="icon-crop_original"></span> crop original | __\&#xe86c;__ | <span class="icon-crop_rect"></span> crop rect | __\&#xe86d;__ | <span class="icon-crop_circular"></span> crop circular | __\&#xe86e;__ |
 | <span class="icon-badge"></span> badge | __\&#xe86f;__ | <span class="icon-notes"></span> notes | __\&#xe870;__ | <span class="icon-time"></span> time | __\&#xe871;__ |
-| <span class="icon-calendar_agenda"></span> calendar_agenda | __\&#xe872;__ | <span class="icon-arrows"></span> arrows | __\&#xe873;__ | <span class="icon-video-camera"></span> video-camera | __\&#xe87;__ |
+| <span class="icon-calendar_agenda"></span> calendar agenda | __\&#xe872;__ | <span class="icon-arrows"></span> arrows | __\&#xe873;__ | <span class="icon-video-camera"></span> video-camera | __\&#xe87;__ |
 | <span class="icon-check-3"></span> check | __\&#xe876;__ | <span class="icon-cancel-3"></span> cancel | __\&#xe877;__ | <span class="icon-time-3"></span> time | __\&#xe878;__ |
 | <span class="icon-arrow-down"></span> arrow-down | __\&#xe879;__ | <span class="icon-flag"></span> flag | __\&#xe87a;__ | <span class="icon-save"></span> save | __\&#xe87b;__ |
 | <span class="icon-share"></span> share | __\&#xe87c;__ | <span class="icon-menu-custom"></span> menu-custom | __\&#xe87d;__ | <span class="icon-heart-filled"></span> heart-filled | __\&#xe87e;__ |


### PR DESCRIPTION
Two changes:

- Fixed the error where `check` descriptive name was used for dot-3
- Removed underscores from descriptive names (we had a mixed style.. some of them had underscores, while others did not)

Dashes were maintained, but I would ask the designers if we can also take the dashes out, too